### PR TITLE
import solc versions installed via solc-select

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -143,6 +143,13 @@ def import_installed_solc(solcx_binary_path: Union[Path, str] = None) -> List[Ve
     imported_versions = []
     for path in path_list:
         try:
+            # we do not want to copy other solc wrappers, such as the one provided
+            # by e.g., solc-select
+            with path.open("rb") as f:
+                data = f.read(200)
+                if data.startswith(b"#!/usr/bin/") or b"solc_select" in data:
+                    continue
+
             version = wrapper._get_solc_version(path)
             assert version not in get_installed_solc_versions()
         except Exception:

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -131,6 +131,11 @@ def import_installed_solc(solcx_binary_path: Union[Path, str] = None) -> List[Ve
     except (FileNotFoundError, subprocess.CalledProcessError):
         path_list = []
 
+    # if solc-select is installed, try to import versions previously installed with it
+    solcselect_artifacts = Path("~").expanduser() / ".solc-select" / "artifacts"
+    if solcselect_artifacts.exists():
+        path_list.extend(solcselect_artifacts.glob("solc-*"))
+
     # on OSX, also copy all versions of solc from cellar
     if _get_os_name() == "macosx":
         path_list.extend(Path("/usr/local/Cellar").glob("solidity*/**/solc"))


### PR DESCRIPTION
### What I did

Search the path used by `solc-select` for solidity versions to import.

Related issue: #122

### How I did it

glob `~/.solc-select/artifacts` for installed solc binaries.

### How to verify it

```
$ rm -rf ~/.solcx ~/.solc-select
$ pip install solc-select
[...]
$ solc-select install 0.4.26 0.7.6
Installing '0.7.6'...
Version '0.7.6' installed.
Installing '0.4.26'...
Version '0.4.26' installed.
$ python -c 'import solcx; print(solcx.import_installed_solc())'
[Version('0.7.6'), Version('0.4.26')]
```

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog