### PR TITLE
update solc_wrapper to expect return value of 0 from 'help' if solc >= v0.8.10

### DIFF
--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -99,7 +99,10 @@ def solc_wrapper(
     command: List = [str(solc_binary)]
 
     if success_return_code is None:
-        success_return_code = 1 if "help" in kwargs else 0
+        if "help" in kwargs and solc_version < Version("0.8.10"):
+            success_return_code = 1
+        else:
+            success_return_code = 0
 
     if source_files is not None:
         if isinstance(source_files, (str, Path)):

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -40,7 +40,10 @@ def setup(all_versions):
 
 def test_help(popen):
     popen.expect("help")
-    solcx.wrapper.solc_wrapper(help=True, success_return_code=1)
+    if solcx.get_solc_version() < Version("0.8.10"):
+        solcx.wrapper.solc_wrapper(help=True, success_return_code=1)
+    else:
+        solcx.wrapper.solc_wrapper(help=True, success_return_code=0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What I did

Starting with solc v0.8.10, running `solc --help` gives a return value of `0`. It was previously `1`. I added version checking to expect the correct value.

### How I did it

I checked if the solc version being used was < v0.8.10 and set the expected return value accordingly.

### How to verify it

Run the tests

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
