### PR TITLE
use shutil.move instead of os.rename to avoid crashes during install

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -624,7 +624,7 @@ def _install_solc_windows(
     else:
         with zipfile.ZipFile(BytesIO(content)) as zf:
             zf.extractall(str(temp_path))
-            temp_path.rename(install_path)
+            shutil.move(temp_path, install_path)
 
 
 def _validate_installation(version: Version, solcx_binary_path: Union[Path, str, None]) -> None:


### PR DESCRIPTION
`os.rename` crashes in certain scenarios (just happened to me), see the [python docs](https://docs.python.org/3/library/os.html#os.rename). [shutil.move](https://docs.python.org/3/library/shutil.html#shutil.move) handles these cases better, also see this question on [stackoverflow](https://stackoverflow.com/questions/21116510/python-oserror-winerror-17-the-system-cannot-move-the-file-to-a-different-d).

### What I did
Replaced `os.rename` with `shutil.move`.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
