### PR TITLE
feat: make `get_solc_version()` method public

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -138,7 +138,7 @@ def import_installed_solc(solcx_binary_path: Union[Path, str] = None) -> List[Ve
     imported_versions = []
     for path in path_list:
         try:
-            version = wrapper._get_solc_version(path)
+            version = wrapper.get_solc_version(path)
             assert version not in get_installed_solc_versions()
         except Exception:
             continue
@@ -151,7 +151,7 @@ def import_installed_solc(solcx_binary_path: Union[Path, str] = None) -> List[Ve
         shutil.copy(path, copy_path)
         try:
             # confirm that solc still works after being copied
-            assert version == wrapper._get_solc_version(copy_path)
+            assert version == wrapper.get_solc_version(copy_path)
             imported_versions.append(version)
         except Exception:
             _unlink_solc(copy_path)
@@ -630,7 +630,7 @@ def _install_solc_windows(
 def _validate_installation(version: Version, solcx_binary_path: Union[Path, str, None]) -> None:
     binary_path = get_executable(version, solcx_binary_path)
     try:
-        installed_version = wrapper._get_solc_version(binary_path)
+        installed_version = wrapper.get_solc_version(binary_path)
     except Exception:
         _unlink_solc(binary_path)
         raise SolcInstallationError(

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -24,7 +24,7 @@ def get_solc_version(with_commit_hash: bool = False) -> Version:
         solc version
     """
     solc_binary = get_executable()
-    return wrapper._get_solc_version(solc_binary, with_commit_hash)
+    return wrapper.get_solc_version(solc_binary, with_commit_hash)
 
 
 def compile_source(

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -12,6 +12,11 @@ from solcx.exceptions import SolcError, UnknownOption, UnknownValue
 VERSION_REGEX = r"(\d+\.\d+\.\d+)(?:-nightly.\d+.\d+.\d+|)(\+commit.\w+)"
 
 
+def _get_solc_version(solc_binary: Union[Path, str], with_commit_hash: bool = False) -> Version:
+    # TODO: Remove around 0.2.0. Was private, kept to prevent accidentally breaking downstream.
+    return get_solc_version(solc_binary, with_commit_hash=with_commit_hash)
+
+
 def get_solc_version(solc_binary: Union[Path, str], with_commit_hash: bool = False) -> Version:
     stdout_data = subprocess.check_output([str(solc_binary), "--version"], encoding="utf8")
     try:

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -12,8 +12,7 @@ from solcx.exceptions import SolcError, UnknownOption, UnknownValue
 VERSION_REGEX = r"(\d+\.\d+\.\d+)(?:-nightly.\d+.\d+.\d+|)(\+commit.\w+)"
 
 
-def _get_solc_version(solc_binary: Union[Path, str], with_commit_hash: bool = False) -> Version:
-    # private wrapper function to get `solc` version
+def get_solc_version(solc_binary: Union[Path, str], with_commit_hash: bool = False) -> Version:
     stdout_data = subprocess.check_output([str(solc_binary), "--version"], encoding="utf8")
     try:
         match = next(re.finditer(VERSION_REGEX, stdout_data))
@@ -95,7 +94,7 @@ def solc_wrapper(
     else:
         solc_binary = install.get_executable()
 
-    solc_version = _get_solc_version(solc_binary)
+    solc_version = get_solc_version(solc_binary)
     command: List = [str(solc_binary)]
 
     if success_return_code is None:

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -13,7 +13,7 @@ VERSION_REGEX = r"(\d+\.\d+\.\d+)(?:-nightly.\d+.\d+.\d+|)(\+commit.\w+)"
 
 
 def _get_solc_version(solc_binary: Union[Path, str], with_commit_hash: bool = False) -> Version:
-    # TODO: Remove around 0.2.0. Was private, kept to prevent accidentally breaking downstream.
+    # TODO: Remove around 1.2.0. Was private, kept to prevent accidentally breaking downstream.
     return get_solc_version(solc_binary, with_commit_hash=with_commit_hash)
 
 

--- a/tests/install/test_compile.py
+++ b/tests/install/test_compile.py
@@ -22,7 +22,7 @@ def test_compile_already_installed():
 
 @pytest.mark.skipif("sys.platform == 'win32'")
 def test_compile(compile_mock, solc_binary, cwd):
-    version = solcx.wrapper._get_solc_version(solc_binary)
+    version = solcx.wrapper.get_solc_version(solc_binary)
     solcx.compile_solc(version)
 
     assert os.getcwd() == cwd
@@ -31,7 +31,7 @@ def test_compile(compile_mock, solc_binary, cwd):
 
 @pytest.mark.skipif("sys.platform == 'win32'")
 def test_compile_install_deps_fails(compile_mock, solc_binary, cwd):
-    version = solcx.wrapper._get_solc_version(solc_binary)
+    version = solcx.wrapper.get_solc_version(solc_binary)
     compile_mock.raise_on("sh")
     solcx.compile_solc(version)
 

--- a/tests/install/test_import_solc.py
+++ b/tests/install/test_import_solc.py
@@ -4,7 +4,7 @@ import solcx
 
 
 def test_import_solc(monkeypatch, solc_binary, nosolc):
-    version = solcx.wrapper._get_solc_version(solc_binary)
+    version = solcx.wrapper.get_solc_version(solc_binary)
 
     monkeypatch.setattr("solcx.install._get_which_solc", lambda: solc_binary)
     assert solcx.import_installed_solc() == [version]
@@ -14,7 +14,7 @@ def test_import_solc(monkeypatch, solc_binary, nosolc):
 
 def test_import_solc_fails_after_importing(monkeypatch, solc_binary, nosolc):
     count = 0
-    version = solcx.wrapper._get_solc_version(solc_binary)
+    version = solcx.wrapper.get_solc_version(solc_binary)
 
     def version_mock(*args):
         # the first version call succeeds, the second attempt fails
@@ -26,7 +26,7 @@ def test_import_solc_fails_after_importing(monkeypatch, solc_binary, nosolc):
         raise Exception
 
     monkeypatch.setattr("solcx.install._get_which_solc", lambda: solc_binary)
-    monkeypatch.setattr("solcx.wrapper._get_solc_version", version_mock)
+    monkeypatch.setattr("solcx.wrapper.get_solc_version", version_mock)
 
     assert solcx.import_installed_solc() == []
     assert not nosolc.joinpath(solc_binary.name).exists()

--- a/tests/install/test_validate_installation.py
+++ b/tests/install/test_validate_installation.py
@@ -10,7 +10,7 @@ from solcx.exceptions import SolcInstallationError, UnexpectedVersionError, Unex
 
 
 def test_validate_installation_wrong_version(monkeypatch, install_mock, install_path):
-    monkeypatch.setattr("solcx.wrapper._get_solc_version", lambda k: Version("0.0.0"))
+    monkeypatch.setattr("solcx.wrapper.get_solc_version", lambda k: Version("0.0.0"))
 
     with pytest.raises(UnexpectedVersionError):
         solcx.install_solc()
@@ -19,8 +19,8 @@ def test_validate_installation_wrong_version(monkeypatch, install_mock, install_
 
 
 def test_validate_installation_nightly(monkeypatch, install_mock, solc_binary, install_path):
-    version = solcx.wrapper._get_solc_version(solc_binary)
-    monkeypatch.setattr("solcx.wrapper._get_solc_version", lambda k: Version(f"{version}-nightly"))
+    version = solcx.wrapper.get_solc_version(solc_binary)
+    monkeypatch.setattr("solcx.wrapper.get_solc_version", lambda k: Version(f"{version}-nightly"))
 
     with pytest.warns(UnexpectedVersionWarning):
         solcx.install_solc()


### PR DESCRIPTION
### What I did

I would like to use the `get_solc_version()` and not worry about it breaking due to it being private.
This PR intends to include the changes needed to accommodate  that.

### How I did it

* Remove implementation to method withou underscore
* Add method with underscore back to point to method without underscore (just in case)

### How to verify it

Let me know if it would be ok to make this change.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
