### PR TITLE
Use first if multiple files returned by where.exe

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -105,7 +105,7 @@ def get_solcx_install_folder(solcx_binary_path: Union[Path, str] = None) -> Path
 def _get_which_solc() -> Path:
     # get the path for the currently installed `solc` version, if any
     if _get_os_name() == "windows":
-        response = subprocess.check_output(["where.exe", "solc"], encoding="utf8").strip()
+        response = subprocess.check_output(["where.exe", "solc"], encoding="utf8").strip().split('\n')[0]
     else:
         response = subprocess.check_output(["which", "solc"], encoding="utf8").strip()
 


### PR DESCRIPTION
### What I did
 
I added code for when "where.exe" finds multiple solc executables. Previously this would cause the solc compiler to be not found when trying to compile a file. Now only the first line of output from where.exe is kept and everything works as expected.

Related issue: #

### How I did it

### How to verify it

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
