### PR TITLE
Add kwargs to compile functions by source and file

### DIFF
--- a/solcx/main.py
+++ b/solcx/main.py
@@ -47,6 +47,7 @@ def compile_source(
     solc_binary: Union[str, Path] = None,
     solc_version: Version = None,
     allow_empty: bool = False,
+    **kwargs: Any,
 ) -> Dict:
     """
     Compile a Solidity contract.
@@ -128,6 +129,7 @@ def compile_source(
         no_optimize_yul=no_optimize_yul,
         yul_optimizations=yul_optimizations,
         allow_empty=allow_empty,
+        **kwargs,
     )
 
 
@@ -151,6 +153,7 @@ def compile_files(
     solc_binary: Union[str, Path] = None,
     solc_version: Version = None,
     allow_empty: bool = False,
+    **kwargs: Any,
 ) -> Dict:
     """
     Compile one or more Solidity source files.
@@ -232,6 +235,7 @@ def compile_files(
         no_optimize_yul=no_optimize_yul,
         yul_optimizations=yul_optimizations,
         allow_empty=allow_empty,
+        **kwargs,
     )
 
 

--- a/tests/main/conftest.py
+++ b/tests/main/conftest.py
@@ -20,3 +20,24 @@ def wrapper_mock(monkeypatch):
     mock = WrapperMock()
     monkeypatch.setattr("solcx.wrapper.solc_wrapper", mock)
     yield mock
+
+
+class CompileCombinedJsonMock:
+    """
+    Simple mock for solcx.main._compile_combined_json
+    """
+
+    def __call__(self, **kwargs):
+        for key, value in self.kwargs.items():
+            assert kwargs[key] == value
+        return {}
+
+    def expect(self, **kwargs):
+        self.kwargs = kwargs
+
+
+@pytest.fixture
+def compile_combined_json_mock(monkeypatch):
+    mock = CompileCombinedJsonMock()
+    monkeypatch.setattr("solcx.main._compile_combined_json", mock)
+    yield mock

--- a/tests/main/test_compile_files.py
+++ b/tests/main/test_compile_files.py
@@ -122,3 +122,8 @@ def test_solc_version(wrapper_mock, all_versions, foo_path):
     solc_binary = solcx.install.get_executable(all_versions)
     wrapper_mock.expect(solc_binary=solc_binary)
     solcx.compile_files([foo_path], ["abi"], solc_version=all_versions, allow_empty=True)
+
+
+def test_value_kwargs(compile_combined_json_mock, foo_path):
+    compile_combined_json_mock.expect(random_kwarg="random-value")
+    solcx.compile_files(foo_path, output_values=["abi"], random_kwarg="random-value")

--- a/tests/main/test_compile_source.py
+++ b/tests/main/test_compile_source.py
@@ -104,3 +104,8 @@ def test_solc_version(wrapper_mock, all_versions, foo_source):
     solc_binary = solcx.install.get_executable(all_versions)
     wrapper_mock.expect(solc_binary=solc_binary)
     solcx.compile_source(foo_source, ["abi"], solc_version=all_versions, allow_empty=True)
+
+
+def test_value_kwargs(compile_combined_json_mock, foo_source):
+    compile_combined_json_mock.expect(random_kwarg="random-value")
+    solcx.compile_files(foo_source, output_values=["abi"], random_kwarg="random-value")

--- a/tests/main/test_compile_source.py
+++ b/tests/main/test_compile_source.py
@@ -108,4 +108,4 @@ def test_solc_version(wrapper_mock, all_versions, foo_source):
 
 def test_value_kwargs(compile_combined_json_mock, foo_source):
     compile_combined_json_mock.expect(random_kwarg="random-value")
-    solcx.compile_files(foo_source, output_values=["abi"], random_kwarg="random-value")
+    solcx.compile_source(foo_source, output_values=["abi"], random_kwarg="random-value")


### PR DESCRIPTION
### What I did

Added kwargs to `compile_source` and `compile_files` functions

Related issue: https://github.com/ApeWorX/py-solc-x/issues/133

### How I did it

### How to verify it

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] I have updated the documentation (README.md)
- [ ] I have added an entry to the changelog
