### PR TITLE
chore: ease packaging version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     python_requires=">=3.8,<4",
     install_requires=[
         "requests>=2.19.0,<3",
-        "packaging>=23.1,<24",
+        "packaging>=23.1",
     ],
     extras_require=extras_require,
     py_modules=["solcx"],


### PR DESCRIPTION
Packaging uses calendar versioning so there is no need to limit the upper version.

See also issues vyperlang/vvm#39, vyperlang/vyper#4590.

### What I did
This patch removed the upper version limit for packaging.

fixes: n/a

### How I did it
Relaxed dependency constraint.

### How to verify it
The package should install just fine with a modern packaging versions.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)